### PR TITLE
change method to get access on a pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 # v0.1.0
 
+- Use `attach` method and no more `exec` 
+
+# v0.1.0
+
 - First release

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ You can also set these parameters for customization of the duplicata:
  - `cpu`
  - `memory`
  - `ttl`
- - `shell`
 
 Already created duplicatas remain 4h (by default) and you can exec into them as long they're running.
 
@@ -33,7 +32,6 @@ Flags:
   -t, --ttl=14400            Time to live of pods is seconds
   -n, --namespace="default"  Namespace
   -p, --pod=POD              Pod
-  -s, --shell="sh"           Shell to use
   -c, --cpu=CPU              cpu
   -m, --memory=MEMORY        Memory
   -k, --kubeconfig=$HOME/.kube/config  


### PR DESCRIPTION
This PR introduces a new way to attach to `duplicata` pod. The pod is now started with a `sh` and we attach to it, no more an `exec`.

This leads 2 changes:
* we can't choose anymore the shell to use (it's `sh` in every cases, to be able to work almost everywhere)
* every action we run in Pod appears in logs (useful for security purpose)