### PR TITLE
Add support for specifying Kubernetes context via --context flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 This app is a plugin for `kubectl`, it allows you to duplicate a running Pod and auto-exec into. The list of Pods is filterable, and you can select the namespace you want.
 
-You can also set these parameters for customization of the duplicata:
+You can also set these parameters for customization of the duplicate:
  - `cpu`
  - `memory`
  - `ttl`
 
-Already created duplicatas remain 4h (by default) and you can exec into them as long they're running.
+Already created duplicates remain 4h (by default) and you can exec into them as long they're running.
 
 ## Requirements
 
@@ -41,7 +41,7 @@ Flags:
 
 ### Install
 
-Download latest release from https://github.com/qonto/kubectl-duplicate/releases and extract `kubectl-duplicate` into your `/usr/loca/bin` and run `chmod -x /usr/local/bin/kubectl-duplicate`.
+Download latest release from https://github.com/qonto/kubectl-duplicate/releases and extract `kubectl-duplicate` into your `/usr/local/bin` and run `chmod -x /usr/local/bin/kubectl-duplicate`.
 
 ### Build
 
@@ -69,14 +69,14 @@ xattr -d com.apple.quarantine /usr/local/bin/kubectl-duplicate
         falcosidekick-5f44cb5bff-jh9wk
     ```
 
-* List pods with already created duplicatas:
+* List pods with already created duplicates:
 
     ```shell
     Search: █
     ? Pods: 
-        falcosidekick-duplicata-nglvr-f569r [duplicata]
-      > falcosidekick-duplicata-kzx9z-kpjh6 [duplicata]
-        falcosidekick-duplicata-mtb9x-lb29p [duplicata]
+        falcosidekick-duplicate-nglvr-f569r [duplicate]
+      > falcosidekick-duplicate-kzx9z-kpjh6 [duplicate]
+        falcosidekick-duplicate-mtb9x-lb29p [duplicate]
         falcosidekick-5f44cb5bff-94sqc
         falcosidekick-5f44cb5bff-jh9wk
         falcosidekick-ui-867f5d6f7-76lfx

--- a/pkg/create/create.go
+++ b/pkg/create/create.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// Job creates the Job for Duplicata
+// Job creates the Job for duplicate
 func Job(clientset *kubernetes.Clientset, config config.Configuration, deployment appsv1.Deployment, container corev1.Container) (*batchv1.Job, error) {
 	execAction := new(corev1.ExecAction)
 	execAction.Command = []string{"true"}
@@ -51,7 +51,7 @@ func Job(clientset *kubernetes.Clientset, config config.Configuration, deploymen
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: deployment.ObjectMeta.Name + "-duplicata-",
+			GenerateName: deployment.ObjectMeta.Name + "-duplicate-",
 			Annotations: map[string]string{
 				"end-at": endAt.Format("2006-01-02 15:04:05"),
 			},
@@ -65,7 +65,7 @@ func Job(clientset *kubernetes.Clientset, config config.Configuration, deploymen
 			BackoffLimit:            &backoffLimit,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: deployment.ObjectMeta.Name + "-duplicata-",
+					GenerateName: deployment.ObjectMeta.Name + "-duplicate-",
 					Annotations: map[string]string{
 						"end-at": endAt.Format("2006-01-02 15:04:05"),
 					},

--- a/pkg/list/list.go
+++ b/pkg/list/list.go
@@ -55,12 +55,12 @@ func PodsForJob(clientset *kubernetes.Clientset, config config.Configuration, jo
 func sort(pods []corev1.Pod) []corev1.Pod {
 	var sortedPods []corev1.Pod
 	for _, i := range pods {
-		if strings.Contains(i.ObjectMeta.Name, "-duplicata-") {
+		if strings.Contains(i.ObjectMeta.Name, "-duplicate-") {
 			sortedPods = append(sortedPods, i)
 		}
 	}
 	for _, i := range pods {
-		if !strings.Contains(i.ObjectMeta.Name, "-duplicata-") {
+		if !strings.Contains(i.ObjectMeta.Name, "-duplicate-") {
 			sortedPods = append(sortedPods, i)
 		}
 	}

--- a/pkg/selector/selector.go
+++ b/pkg/selector/selector.go
@@ -23,8 +23,8 @@ func Pod(pods []corev1.Pod, match string) corev1.Pod {
 
 	templates := &promptui.SelectTemplates{
 		// Label: `		`,
-		Active:   `{{ "> " | cyan | bold }}{{ .ObjectMeta.Name | cyan | bold }}{{if (index .ObjectMeta.Annotations "end-at")}}{{ " [duplicata]" }}{{ end }}`,
-		Inactive: `  {{ .ObjectMeta.Name }}{{if (index .ObjectMeta.Annotations "end-at")}}{{ " [duplicata]" }}{{ end }}`,
+		Active:   `{{ "> " | cyan | bold }}{{ .ObjectMeta.Name | cyan | bold }}{{if (index .ObjectMeta.Annotations "end-at")}}{{ " [duplicate]" }}{{ end }}`,
+		Inactive: `  {{ .ObjectMeta.Name }}{{if (index .ObjectMeta.Annotations "end-at")}}{{ " [duplicate]" }}{{ end }}`,
 		Details: `
 {{if (index .ObjectMeta.Annotations "end-at")}}{{ " End: " }}{{ index .ObjectMeta.Annotations "end-at" | bold }}{{ end }}`,
 	}


### PR DESCRIPTION
### New Feature Additions:

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R26-R27): Introduced `--no-auto-exec` and `--context` flags to provide more control over the execution behavior and Kubernetes context. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R26-R27) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R37-R44) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R57-R63) [[4]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R98-R104)